### PR TITLE
add $schema to commandStatusCode.json

### DIFF
--- a/api/part2/openapi/schemas/json/commandStatusCode.json
+++ b/api/part2/openapi/schemas/json/commandStatusCode.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "string",
   "oneOf": [
     { "const": "PENDING", "description": "The command is pending, meaning it has been received by the system but no decision to accept or reject it has been taken." },


### PR DESCRIPTION
This single file is missing the `$schema` annotation, causing some parsers to fail.