### PR TITLE
Convert required to array

### DIFF
--- a/api/part1/openapi/responses/resourceLinks.yaml
+++ b/api/part1/openapi/responses/resourceLinks.yaml
@@ -3,7 +3,8 @@ content:
   application/json:
     schema:
       type: object
-      required: items
+      required:
+        - items
       properties:
         items:
           description: Array of resource URIs


### PR DESCRIPTION
Fix incorrect `required` (should be array).