### PR TITLE
fix invalid references to removed files

### DIFF
--- a/api/part2/asyncapi/asyncapi-connectedsystems-2.yaml
+++ b/api/part2/asyncapi/asyncapi-connectedsystems-2.yaml
@@ -18,7 +18,7 @@ channels:
         title: System Event
         contentType: application/sml+json
         payload:
-          $ref: ../openapi/schemas/json/systemEvent_view.json
+          $ref: ../openapi/schemas/json/systemEvent.json
     publish:
       summary: Publish events for a specific system
       message:
@@ -26,7 +26,7 @@ channels:
         title: System Event
         contentType: application/sml+json
         payload:
-          $ref: ../openapi/schemas/json/systemEvent_create.json
+          $ref: ../openapi/schemas/json/systemEvent.json
 
 
   systems/events:
@@ -40,7 +40,7 @@ channels:
         title: System Event
         contentType: application/sml+json
         payload:
-          $ref: ../openapi/schemas/json/systemEvent_view.json
+          $ref: ../openapi/schemas/json/systemEvent.json
 
 
   datastreams/{dataStreamId}/observations:
@@ -54,7 +54,7 @@ channels:
         title: Observation
         contentType: application/om+json
         payload:
-          $ref: ../openapi/schemas/json/observation_view.json
+          $ref: ../openapi/schemas/json/observation.json
     publish:
       summary: Publish observations in a specific datastream
       message:
@@ -62,7 +62,7 @@ channels:
         title: Observation
         contentType: application/om+json
         payload:
-          $ref: ../openapi/schemas/json/observation_create.json
+          $ref: ../openapi/schemas/json/observation.json
 
 
   controls/{controlStreamId}/commands:
@@ -76,7 +76,7 @@ channels:
         title: Command
         contentType: application/cmd+json
         payload:
-          $ref: ../openapi/schemas/json/command_view.json
+          $ref: ../openapi/schemas/json/command.json
     publish:
       summary: Publish commands in a specific control stream
       message:
@@ -84,7 +84,7 @@ channels:
         title: Command
         contentType: application/cmd+json
         payload:
-          $ref: ../openapi/schemas/json/command_create.json
+          $ref: ../openapi/schemas/json/command.json
 
 
   controls/{controlStreamId}/commands/{cmdId}/status:
@@ -100,7 +100,7 @@ channels:
         title: Command
         contentType: application/cmd+json
         payload:
-          $ref: ../openapi/schemas/json/commandStatus_view.json
+          $ref: ../openapi/schemas/json/commandStatus.json
     publish:
       summary: Publish commands in a specific control stream
       message:
@@ -108,4 +108,4 @@ channels:
         title: Command
         contentType: application/cmd+json
         payload:
-          $ref: ../openapi/schemas/json/commandStatus_create.json
+          $ref: ../openapi/schemas/json/commandStatus.json

--- a/api/part2/openapi/examples/schemas/commandSchema-ptz-jsonschema-byref.json
+++ b/api/part2/openapi/examples/schemas/commandSchema-ptz-jsonschema-byref.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "https://raw.githubusercontent.com/opengeospatial/ogcapi-connected-systems/master/api/part2/openapi/schemas/json/command_view.json" },
+    { "$ref": "https://raw.githubusercontent.com/opengeospatial/ogcapi-connected-systems/master/api/part2/openapi/schemas/json/command.json" },
     {
       "properties": {
         "parameters": {

--- a/api/part2/openapi/examples/schemas/observationSchema-scalar-json-jsonschema-byref.json
+++ b/api/part2/openapi/examples/schemas/observationSchema-scalar-json-jsonschema-byref.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "https://raw.githubusercontent.com/opengeospatial/ogcapi-connected-systems/master/api/part2/openapi/schemas/json/observation_view.json" },
+    { "$ref": "https://raw.githubusercontent.com/opengeospatial/ogcapi-connected-systems/master/api/part2/openapi/schemas/json/observation.json" },
     {
       "properties": {
         "result": {


### PR DESCRIPTION
Files 

- `command_view`
- `observation_view`
- `command_create`
- `observation_create`

were removed in favor of specifying view-only/payload-only properties with the keywords `readOnly`/`writeOnly`