### PR TITLE
Add GH-Workflow for bundling of schemas

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -1,0 +1,38 @@
+# Simple workflow for bundling schemas into one
+name: Bundle schemas
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  bundle_part1:
+    runs-on: ubuntu-latest
+    name: part1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Redocly CLI Bundle Part 1
+        uses: fluximus-prime/redocly-cli-github-action@v1
+        with:
+          args: 'bundle api/part1/openapi/openapi-connectedsystems-1.yaml -o ogcapi-connectedsystems-1.bundled.oas31.yaml'
+
+      - name: Redocly CLI Bundle Part 2
+        uses: fluximus-prime/redocly-cli-github-action@v1
+        with:
+          args: 'bundle -d api/part2/openapi/openapi-connectedsystems-2.yaml -o ogcapi-connectedsystems-2.bundled.oas31.yaml'
+
+      - name: release
+        uses: softprops/action-gh-release@v2
+        # if: startsWith(github.ref, 'refs/tags/')
+        id: create_release
+        with:
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: |
+            ogcapi-connectedsystems-1.bundled.oas31.yaml
+            ogcapi-connectedsystems-2.bundled.oas31.yaml

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -4,14 +4,17 @@ name: Bundle schemas
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  push:
+    tags:
+    - "*"
 
 permissions:
   contents: write
 
 jobs:
-  bundle_part1:
+  bundle:
     runs-on: ubuntu-latest
-    name: part1
+    name: generate-bundle
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  packages: write
+  contents: write
 
 jobs:
   bundle_part1:

--- a/api/part2/openapi/schemas/json/controlStream.json
+++ b/api/part2/openapi/schemas/json/controlStream.json
@@ -66,7 +66,7 @@
             },
             {
               "description": "Time extent spanning all issue times of commands in this control stream",
-              "$ref": "../common/commonDefs.json#/$def/TimePeriod",
+              "$ref": "../common/commonDefs.json#/$defs/TimePeriod",
               "readOnly": true
             }
           ]
@@ -78,7 +78,7 @@
             },
             {
               "description": "Time extent spanning all execution times of commands in this control stream",
-              "$ref": "../common/commonDefs.json#/$def/TimePeriod",
+              "$ref": "../common/commonDefs.json#/$defs/TimePeriod",
               "readOnly": true
             }
           ]


### PR DESCRIPTION
Adds workflow to bundle schemas to GH-Actions.

Releases are initially marked as `pre-release`, and can then be manually upgraded to full-release.

fixes #137 

