### PR TITLE
Add missing recursive parameter to deployments OpenAPI

### DIFF
--- a/api/part1/openapi/paths/deployments.yaml
+++ b/api/part1/openapi/paths/deployments.yaml
@@ -16,6 +16,8 @@ get:
     - $ref: ../parameters/obsPropIdList.yaml
     - $ref: ../parameters/controlPropIdList.yaml
     #- $ref: '#/components/parameters/select'
+    - $ref: ../parameters/recursive.yaml
+      description: If true, instructs the server to include all subdeployments, at all nesting levels, in the search results.
     - $ref: ../parameters/limit.yaml
   responses:
     '200':


### PR DESCRIPTION
## Summary

This PR adds the shared `recursive` query parameter to the `GET /deployments` OpenAPI operation, aligning the API definition with Part 1 Requirement 21, `/req/subdeployment/recursive-search-deployments`.

The parameter is already defined and used by the Systems and Subdeployments operations. The `/deployments` path omitted that reference, preventing generated API documentation and OpenAPI-aware tools from advertising the required recursive search behavior.

## Validation

- Bundled the Part 1 OpenAPI definition with Redocly CLI 1.34.5.
- Confirmed that `GET /deployments` exposes the optional Boolean `recursive` parameter with a default of `false`.
- Confirmed that the deployment-specific description appears in the bundle.
- Confirmed that the change introduces no new bundling warnings; the 11 existing duplicate-schema-name warnings remain unchanged.

Addresses #169.
