### PR TITLE
Add validTime to the Procedure GeoJSON schema

### DIFF
--- a/api/part1/openapi/schemas/geojson/procedure.json
+++ b/api/part1/openapi/schemas/geojson/procedure.json
@@ -11,6 +11,10 @@
           "properties": {
             "featureType": {
               "$ref": "../common/uris.json#/$defs/ProcedureTypeUris"
+            },
+            "validTime": {
+              "description": "Time period during which the procedure description is valid.",
+              "$ref": "../common/commonDefs.json#/$defs/TimePeriod"
             }
           }
         }


### PR DESCRIPTION
## Summary

- Add the optional `properties/validTime` field required by the Part 1 Procedure model and GeoJSON mapping.
- Reuse the shared `TimePeriod` definition already applied to other GeoJSON resource schemas.

## Validation

- Parsed the updated JSON schema and ran `git diff --check`.
- Generated a forced Redocly diagnostic bundle and confirmed that Procedure `validTime` resolves to bundled `timePeriod`.
- Used focused AJV fixtures matching the repository time schemas: a period ending in `"now"` passed, while one ending in `".."` failed as expected under the current schema.

A normal full Part 1 bundle is currently blocked by an unrelated indentation error in `api/part1/openapi/paths/systemDeployments.yaml` that is already present on `master` and is unchanged by this PR.

Addresses #174
